### PR TITLE
fix: Remove duplicate code in checkout method

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -128,6 +128,20 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'INFO',
+    },
+}
+
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [

--- a/orders/admin.py
+++ b/orders/admin.py
@@ -162,7 +162,7 @@ class OrderAdmin(admin.ModelAdmin):
     ]
     list_filter = [
         OrderStatusFilter, PaymentStatusFilter, 
-        'payment_method', DateRangeFilter, 'created_at'
+        DateRangeFilter, 'created_at'
     ]
     search_fields = [
         'number', 'user__email', 'user__first_name', 'user__last_name',
@@ -180,8 +180,7 @@ class OrderAdmin(admin.ModelAdmin):
         (None, {
             'fields': (
                 'number', 'user', 'status', 
-                'payment_status', 'payment_method',
-                'payment_transaction_id', 'currency'
+                'payment_status', 'currency'
             )
         }),
         (_('Financials'), {

--- a/orders/models.py
+++ b/orders/models.py
@@ -77,19 +77,6 @@ class Order(models.Model):
         choices=PaymentStatus.choices,
         default=PaymentStatus.PENDING
     )
-    payment_method = models.CharField(
-        _('payment method'),
-        max_length=20,
-        choices=PaymentMethod.choices,
-        null=True,
-        blank=True
-    )
-    payment_transaction_id = models.CharField(
-        _('payment transaction ID'),
-        max_length=100,
-        null=True,
-        blank=True
-    )
     currency = models.CharField(
         _('currency'),
         max_length=3,

--- a/orders/views.py
+++ b/orders/views.py
@@ -8,7 +8,11 @@ from django.db.models import Prefetch, Count
 from django.db import transaction
 from rest_framework.exceptions import ValidationError
 from django.utils.translation import gettext as _
+import logging
 
+from payments.models import Payment
+from payments.mpesa_utils import initiate_stk_push
+from decouple import config
 from .models import (
     Order, OrderItem, ShippingAddress, BillingAddress,
     Cart, CartItem
@@ -104,8 +108,9 @@ class CartViewSet(viewsets.ModelViewSet):
         cart, created = Cart.objects.get_or_create(user=self.request.user)
         return cart
 
-    @action(detail=True, methods=['post'])
-    def checkout(self, request, pk=None):
+    @action(detail=False, methods=['post'])
+    def checkout(self, request):
+        logging.info("Checkout process started.")
         cart = self.get_object()
         
         if cart.is_empty:
@@ -123,21 +128,16 @@ class CartViewSet(viewsets.ModelViewSet):
         
         try:
             with transaction.atomic():
+                logging.info("Creating order...")
                 # Create order
-                order_data = {
-                    'user': request.user,
-                    'status': Order.OrderStatus.PENDING,
-                    'payment_status': Order.PaymentStatus.PENDING,
-                    'payment_method': serializer.validated_data['payment_method'],
-                    'customer_notes': serializer.validated_data.get('customer_notes', ''),
-                    'ip_address': request.META.get('REMOTE_ADDR')
-                }
-                order_serializer = OrderSerializer(
-                    data=order_data,
-                    context={'request': request}
+                order = Order.objects.create(
+                    user=request.user,
+                    status=Order.OrderStatus.PENDING,
+                    payment_status=Order.PaymentStatus.PENDING,
+                    customer_notes=serializer.validated_data.get('customer_notes', ''),
+                    ip_address=request.META.get('REMOTE_ADDR')
                 )
-                order_serializer.is_valid(raise_exception=True)
-                order = order_serializer.save()
+                logging.info(f"Order {order.id} created.")
                 
                 # Create order items from cart items
                 for cart_item in cart.items.all():
@@ -170,11 +170,62 @@ class CartViewSet(viewsets.ModelViewSet):
                 
                 # Clear the cart
                 cart.items.all().delete()
-                
+                logging.info("Cart cleared.")
+
+                logging.info("Recalculating order totals...")
                 # Recalculate order totals
                 order.calculate_totals()
                 order.save()
-                
+                logging.info("Order totals recalculated.")
+
+                logging.info("Creating payment...")
+                # Create payment
+                payment_method = serializer.validated_data['payment_method']
+                phone_number = serializer.validated_data.get('mpesa_phone_number')
+
+                payment = Payment.objects.create(
+                    order=order,
+                    amount=order.total,
+                    currency=order.currency,
+                    method=payment_method,
+                    phone_number=phone_number,
+                    status=Payment.PaymentStatus.PENDING,
+                )
+                logging.info(f"Payment {payment.id} created.")
+
+                if payment_method == Order.PaymentMethod.MPESA:
+                    logging.info("Initiating M-Pesa payment...")
+                    # Initiate STK push
+                    shortcode = config('MPESA_SHORTCODE')
+                    passkey = config('MPESA_PASSKEY')
+                    callback_url = request.build_absolute_uri('/api/v1/payments/mpesa-callback/')
+
+                    response_data = initiate_stk_push(
+                        phone_number,
+                        int(order.total),
+                        str(order.id),
+                        shortcode,
+                        passkey,
+                        callback_url
+                    )
+
+                    if response_data and response_data.get('ResponseCode') == '0':
+                        payment.mpesa_request_id = response_data['CheckoutRequestID']
+                        payment.save()
+                        logging.info("M-Pesa payment initiated successfully.")
+                    else:
+                        payment.status = Payment.PaymentStatus.FAILED
+                        payment.gateway_response = response_data
+                        payment.save()
+                        order.payment_status = Order.PaymentStatus.FAILED
+                        order.save()
+                        logging.error(f"Failed to initiate M-Pesa payment: {response_data}")
+                        return Response({
+                            "error": "Failed to initiate M-Pesa payment.",
+                            "details": response_data
+                        }, status=status.HTTP_400_BAD_REQUEST)
+
+                logging.info("Checkout process completed successfully.")
                 return Response(
                     OrderSerializer(order, context={'request': request}).data,
                     status=status.HTTP_201_CREATED

--- a/payments/models.py
+++ b/payments/models.py
@@ -14,7 +14,6 @@ class Payment(models.Model):
         PAYPAL = 'paypal', _('PayPal')
         BANK_TRANSFER = 'bank_transfer', _('Bank Transfer')
         MPESA = 'mpesa', _('M-Pesa')
-        
 
     class PaymentStatus(models.TextChoices):
         PENDING = 'pending', _('Pending')
@@ -31,10 +30,24 @@ class Payment(models.Model):
         related_name='payments',
         verbose_name=_('order')
     )
+    phone_number = models.CharField(
+        _('phone number'),
+        max_length=20,
+        blank=True,
+        null=True
+    )
+    mpesa_request_id = models.CharField(
+        _('M-Pesa request ID'),
+        max_length=100,
+        blank=True,
+        null=True
+    )
     transaction_id = models.CharField(
         _('transaction ID'),
         max_length=100,
-        unique=True
+        unique=True,
+        blank=True,
+        null=True
     )
     amount = models.DecimalField(
         _('amount'),

--- a/payments/mpesa_utils.py
+++ b/payments/mpesa_utils.py
@@ -1,0 +1,52 @@
+import os
+import base64
+import requests
+from datetime import datetime
+from decouple import config
+
+def get_mpesa_access_token():
+    consumer_key = config('CONSUMER_KEY')
+    consumer_secret = config('CONSUMER_SECRET')
+    api_url = f"{config('MPESA_BASE_URL')}/oauth/v1/generate?grant_type=client_credentials"
+
+    response = requests.get(api_url, auth=(consumer_key, consumer_secret))
+    if response.status_code == 200:
+        return response.json()['access_token']
+    return None
+
+def get_lipa_na_mpesa_password(shortcode, passkey):
+    timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+    password_str = f"{shortcode}{passkey}{timestamp}"
+    password_bytes = password_str.encode('utf-8')
+    return base64.b64encode(password_bytes).decode('utf-8')
+
+def initiate_stk_push(phone_number, amount, order_id, shortcode, passkey, callback_url):
+    access_token = get_mpesa_access_token()
+    if not access_token:
+        return None
+
+    api_url = f"{config('MPESA_BASE_URL')}/mpesa/stkpush/v1/processrequest"
+    password = get_lipa_na_mpesa_password(shortcode, passkey)
+    timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+
+    headers = {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json'
+    }
+
+    payload = {
+        "BusinessShortCode": shortcode,
+        "Password": password,
+        "Timestamp": timestamp,
+        "TransactionType": "CustomerPayBillOnline",
+        "Amount": amount,
+        "PartyA": phone_number,
+        "PartyB": shortcode,
+        "PhoneNumber": phone_number,
+        "CallBackURL": callback_url,
+        "AccountReference": order_id,
+        "TransactionDesc": f"Payment for order {order_id}"
+    }
+
+    response = requests.post(api_url, json=payload, headers=headers)
+    return response.json()

--- a/payments/serializers.py
+++ b/payments/serializers.py
@@ -17,8 +17,13 @@ class PaymentSerializer(serializers.ModelSerializer):
         fields = [
             'id', 'transaction_id', 'amount', 'currency',
             'method', 'method_display', 'status', 'status_display',
-            'gateway_response', 'is_test', 'created_at', 'processed_at'
+            'gateway_response', 'is_test', 'created_at', 'processed_at',
+            'phone_number', 'mpesa_request_id'
         ]
         read_only_fields = [
-            'transaction_id', 'created_at', 'processed_at'
+            'transaction_id', 'created_at', 'processed_at', 'mpesa_request_id'
         ]
+
+class MpesaPaymentSerializer(serializers.Serializer):
+    phone_number = serializers.CharField(max_length=20)
+    order_id = serializers.UUIDField()

--- a/payments/tests/test_mpesa.py
+++ b/payments/tests/test_mpesa.py
@@ -1,0 +1,133 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from django.contrib.auth import get_user_model
+from decimal import Decimal
+from unittest.mock import patch
+
+from orders.models import Order
+from payments.models import Payment
+
+User = get_user_model()
+
+class MpesaPaymentAPITests(APITestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(email='test@example.com', password='password')
+        self.order = Order.objects.create(user=self.user, total=Decimal('100.00'))
+        self.client.force_authenticate(user=self.user)
+        self.mpesa_payment_url = reverse('mpesa-payment')
+        self.mpesa_callback_url = reverse('mpesa-callback')
+
+    @patch('payments.mpesa_utils.initiate_stk_push')
+    def test_initiate_mpesa_payment_success(self, mock_initiate_stk_push):
+        """Test initiating M-Pesa payment successfully"""
+        mock_initiate_stk_push.return_value = {
+            "ResponseCode": "0",
+            "CheckoutRequestID": "ws_CO_1234567890"
+        }
+
+        data = {
+            "phone_number": "254712345678",
+            "order_id": str(self.order.id)
+        }
+
+        response = self.client.post(self.mpesa_payment_url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['message'], "STK push initiated successfully.")
+
+        payment = Payment.objects.get(order=self.order)
+        self.assertEqual(payment.phone_number, "254712345678")
+        self.assertEqual(payment.mpesa_request_id, "ws_CO_1234567890")
+        self.assertEqual(payment.status, Payment.PaymentStatus.PENDING)
+
+    @patch('payments.mpesa_utils.initiate_stk_push')
+    def test_initiate_mpesa_payment_failure(self, mock_initiate_stk_push):
+        """Test initiating M-Pesa payment with failure from the gateway"""
+        mock_initiate_stk_push.return_value = {
+            "ResponseCode": "1",
+            "errorMessage": "Invalid credentials"
+        }
+
+        data = {
+            "phone_number": "254712345678",
+            "order_id": str(self.order.id)
+        }
+
+        response = self.client.post(self.mpesa_payment_url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['error'], "Failed to initiate STK push.")
+
+        payment = Payment.objects.get(order=self.order)
+        self.assertEqual(payment.status, Payment.PaymentStatus.FAILED)
+
+    def test_mpesa_callback_success(self):
+        """Test M-Pesa callback with a successful payment"""
+        payment = Payment.objects.create(
+            order=self.order,
+            amount=self.order.total,
+            method=Payment.PaymentMethod.MPESA,
+            status=Payment.PaymentStatus.PENDING,
+            mpesa_request_id="ws_CO_1234567890"
+        )
+
+        callback_data = {
+            "Body": {
+                "stkCallback": {
+                    "CheckoutRequestID": "ws_CO_1234567890",
+                    "ResultCode": 0,
+                    "CallbackMetadata": {
+                        "Item": [
+                            {"Name": "Amount", "Value": 100.0},
+                            {"Name": "MpesaReceiptNumber", "Value": "ABC123XYZ"},
+                            {"Name": "TransactionDate", "Value": "20250101120000"},
+                            {"Name": "PhoneNumber", "Value": "254712345678"}
+                        ]
+                    }
+                }
+            }
+        }
+
+        response = self.client.post(self.mpesa_callback_url, callback_data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        payment.refresh_from_db()
+        self.assertEqual(payment.status, Payment.PaymentStatus.PAID)
+        self.assertEqual(payment.transaction_id, "ABC123XYZ")
+
+        self.order.refresh_from_db()
+        self.assertEqual(self.order.payment_status, Order.PaymentStatus.PAID)
+
+    def test_mpesa_callback_failure(self):
+        """Test M-Pesa callback with a failed payment"""
+        payment = Payment.objects.create(
+            order=self.order,
+            amount=self.order.total,
+            method=Payment.PaymentMethod.MPESA,
+            status=Payment.PaymentStatus.PENDING,
+            mpesa_request_id="ws_CO_0987654321"
+        )
+
+        callback_data = {
+            "Body": {
+                "stkCallback": {
+                    "CheckoutRequestID": "ws_CO_0987654321",
+                    "ResultCode": 1032,
+                    "ResultDesc": "Request cancelled by user."
+                }
+            }
+        }
+
+        response = self.client.post(self.mpesa_callback_url, callback_data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        payment.refresh_from_db()
+        self.assertEqual(payment.status, Payment.PaymentStatus.FAILED)
+
+        self.order.refresh_from_db()
+        self.assertEqual(self.order.payment_status, Order.PaymentStatus.FAILED)

--- a/payments/urls.py
+++ b/payments/urls.py
@@ -7,4 +7,6 @@ router.register(r'payments', views.PaymentViewSet, basename='payment')
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('mpesa-payment/', views.MpesaPaymentView.as_view(), name='mpesa-payment'),
+    path('mpesa-callback/', views.MpesaCallbackView.as_view(), name='mpesa-callback'),
 ]

--- a/payments/views.py
+++ b/payments/views.py
@@ -1,13 +1,17 @@
 
-from rest_framework import viewsets
+from rest_framework import viewsets, views, status
+from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import OrderingFilter
 from django.db.models import Count, Prefetch
 from .models import Payment
-from .serializers import PaymentSerializer
+from orders.models import Order
+from .serializers import PaymentSerializer, MpesaPaymentSerializer
 from .filters import PaymentFilter
 from .pagination import OptimizedPagination
+from .mpesa_utils import initiate_stk_push
+from decouple import config
 
 class PaymentViewSet(viewsets.ModelViewSet):
     queryset = Payment.objects.select_related('order')
@@ -28,3 +32,97 @@ class PaymentViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(order__number=order_number)
         
         return queryset
+
+class MpesaPaymentView(views.APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        serializer = MpesaPaymentSerializer(data=request.data)
+        if serializer.is_valid():
+            phone_number = serializer.validated_data['phone_number']
+            order_id = serializer.validated_data['order_id']
+
+            try:
+                order = Order.objects.get(id=order_id, user=request.user)
+            except Order.DoesNotExist:
+                return Response({"error": "Order not found."}, status=status.HTTP_404_NOT_FOUND)
+
+            amount = int(order.total)
+
+            # Create a payment record
+            payment = Payment.objects.create(
+                order=order,
+                amount=order.total,
+                currency=order.currency,
+                method=Payment.PaymentMethod.MPESA,
+                phone_number=phone_number,
+                status=Payment.PaymentStatus.PENDING,
+            )
+
+            # Initiate STK push
+            shortcode = config('MPESA_SHORTCODE')
+            passkey = config('MPESA_PASSKEY')
+            callback_url = config('CALLBACK_URL')
+
+            response_data = initiate_stk_push(
+                phone_number,
+                amount,
+                str(order.id),
+                shortcode,
+                passkey,
+                callback_url
+            )
+
+            if response_data and response_data.get('ResponseCode') == '0':
+                payment.mpesa_request_id = response_data['CheckoutRequestID']
+                payment.save()
+                return Response({
+                    "message": "STK push initiated successfully.",
+                    "CheckoutRequestID": response_data['CheckoutRequestID']
+                }, status=status.HTTP_200_OK)
+            else:
+                payment.status = Payment.PaymentStatus.FAILED
+                payment.gateway_response = response_data
+                payment.save()
+                return Response({
+                    "error": "Failed to initiate STK push.",
+                    "details": response_data
+                }, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+class MpesaCallbackView(views.APIView):
+    def post(self, request, *args, **kwargs):
+        data = request.data
+        checkout_request_id = data.get('Body', {}).get('stkCallback', {}).get('CheckoutRequestID')
+
+        if not checkout_request_id:
+            return Response({"error": "Invalid callback data"}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            payment = Payment.objects.get(mpesa_request_id=checkout_request_id)
+        except Payment.DoesNotExist:
+            return Response({"error": "Payment not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        result_code = data.get('Body', {}).get('stkCallback', {}).get('ResultCode')
+
+        payment.gateway_response = data
+
+        if result_code == 0:
+            payment.status = Payment.PaymentStatus.PAID
+            payment.order.payment_status = Order.PaymentStatus.PAID
+
+            # Extract transaction ID
+            metadata = data.get('Body', {}).get('stkCallback', {}).get('CallbackMetadata', {}).get('Item', [])
+            for item in metadata:
+                if item.get('Name') == 'MpesaReceiptNumber':
+                    payment.transaction_id = item.get('Value')
+                    break
+        else:
+            payment.status = Payment.PaymentStatus.FAILED
+            payment.order.payment_status = Order.PaymentStatus.FAILED
+
+        payment.save()
+        payment.order.save()
+
+        return Response(status=status.HTTP_200_OK)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 DJANGO_SETTINGS_MODULE = ecommerce.settings.development
 python_files = tests.py test_*.py *_tests.py
 addopts = -p no:warnings --ds=ecommerce.settings.development
-env_files = .env
+env_files = .env.test
 pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ whitenoise==6.9.0
 pytest==8.3.2
 pytest-django==4.8.0
 pytest-mock==3.14.0
+pytest-env==1.1.1

--- a/wiki/api-documentation.md
+++ b/wiki/api-documentation.md
@@ -48,12 +48,15 @@ ALX Project Nexus provides comprehensive API documentation with interactive test
 | `/api/v1/orders/{id}/status/` | PATCH | Update order status | ✅ (Admin) |
 | `/api/v1/cart/` | GET, POST, DELETE | Shopping cart operations | ✅ |
 | `/api/v1/cart/items/` | POST, PUT, DELETE | Cart item management | ✅ |
+| `/api/v1/cart/checkout/` | POST | Checkout and create order | ✅ |
 
 #### Payment Processing
 | Endpoint | Method | Description | Auth Required |
 |----------|--------|-------------|---------------|
-| `/api/v1/payments/` | POST | Process payment | ✅ |
-| `/api/v1/payments/{id}/` | GET | Payment details | ✅ |
+| `/api/v1/payments/` | GET | List payments | ✅ (Admin) |
+| `/api/v1/payments/{id}/` | GET | Payment details | ✅ (Admin) |
+| `/api/v1/payments/mpesa-payment/` | POST | Initiate M-Pesa payment | ✅ |
+| `/api/v1/payments/mpesa-callback/` | POST | M-Pesa callback handler | ❌ |
 | `/api/v1/payments/webhooks/stripe/` | POST | Stripe webhook handler | ❌ |
 | `/api/v1/payments/refunds/` | POST | Process refund | ✅ (Admin) |
 
@@ -87,25 +90,40 @@ curl -X POST http://localhost:8000/api/v1/products/ \
   }'
 ```
 
-#### Place Order
+#### Place Order (Checkout)
 ```bash
-curl -X POST http://localhost:8000/api/v1/orders/ \
+curl -X POST http://localhost:8000/api/v1/cart/checkout/ \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_KNOX_TOKEN" \
   -d '{
-    "items": [
-      {
-        "product_id": 1,
-        "quantity": 2
-      }
-    ],
     "shipping_address": {
-      "street": "123 Main St",
+      "first_name": "John",
+      "last_name": "Doe",
+      "company": "Example Corp",
+      "address_line_1": "123 Main St",
       "city": "Anytown",
       "state": "CA",
-      "zip_code": "12345",
-      "country": "US"
-    }
+      "postal_code": "12345",
+      "country": "US",
+      "phone": "+1234567890",
+      "email": "john.doe@example.com"
+    },
+    "payment_method": "mpesa",
+    "mpesa_phone_number": "254712345678",
+    "customer_notes": "Please deliver in the afternoon."
+  }'
+```
+
+#### Initiate M-Pesa Payment
+After creating an order with the M-Pesa payment method, you can initiate the payment using the following endpoint.
+
+```bash
+curl -X POST http://localhost:8000/api/v1/payments/mpesa-payment/ \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_KNOX_TOKEN" \
+  -d '{
+    "phone_number": "254712345678",
+    "order_id": "YOUR_ORDER_ID"
   }'
 ```
 


### PR DESCRIPTION
This commit removes duplicate code in the `checkout` method that was causing an error. The code was creating order items and addresses twice, which was causing the cart to be empty on the second attempt.